### PR TITLE
Add a benchmarks for the use of attributes vs static methods

### DIFF
--- a/src/AD.BaseTypes.Benchmarks/AD.BaseTypes.Benchmarks.csproj
+++ b/src/AD.BaseTypes.Benchmarks/AD.BaseTypes.Benchmarks.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AD.BaseTypes\AD.BaseTypes.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/AD.BaseTypes.Benchmarks/MaxLengthBenchmark.cs
+++ b/src/AD.BaseTypes.Benchmarks/MaxLengthBenchmark.cs
@@ -1,0 +1,16 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace AD.BaseTypes.Benchmark;
+
+[MemoryDiagnoser]
+public class MaxLengthBenchmark
+{
+    private int maxLength = new Random().Next();
+    private string value = "teststring";
+
+    [Benchmark]
+    public void WithAttribute() => new MaxLengthStringAttribute(maxLength).Validate(value);
+
+    [Benchmark]
+    public void WithStaticFunction() => StringValidation.MaxLength(maxLength, value);
+}

--- a/src/AD.BaseTypes.Benchmarks/Program.cs
+++ b/src/AD.BaseTypes.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+﻿using BenchmarkDotNet.Running;
+
+BenchmarkRunner.Run(typeof(Program).Assembly);

--- a/src/AD.BaseTypes.sln
+++ b/src/AD.BaseTypes.sln
@@ -32,6 +32,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		ESD_512.png = ESD_512.png
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AD.BaseTypes.Benchmarks", "AD.BaseTypes.Benchmarks\AD.BaseTypes.Benchmarks.csproj", "{5370BAD0-143D-40AF-ADA7-2FDCBA8EAAC0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +84,10 @@ Global
 		{FD16942F-A075-4F71-9B31-F3807DF77F4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD16942F-A075-4F71-9B31-F3807DF77F4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD16942F-A075-4F71-9B31-F3807DF77F4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5370BAD0-143D-40AF-ADA7-2FDCBA8EAAC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5370BAD0-143D-40AF-ADA7-2FDCBA8EAAC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5370BAD0-143D-40AF-ADA7-2FDCBA8EAAC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5370BAD0-143D-40AF-ADA7-2FDCBA8EAAC0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AD.BaseTypes/StringValidation.cs
+++ b/src/AD.BaseTypes/StringValidation.cs
@@ -1,6 +1,6 @@
 ﻿namespace AD.BaseTypes;
 
-static class StringValidation
+public static class StringValidation
 {
     public static void MinLength(int minLength, string value)
     {


### PR DESCRIPTION
I would like to use those primitives everywhere as a way to protect functions from getting called with the wrong order of parameters and provoking runtime bugs and as a way to make the code secure by design with validations. 

The results shows a 4x performance and removes memory allocation if we use static methods instead of instantiating attributes.
```
|             Method |     Mean |     Error |    StdDev |   Gen0 | Allocated |
|------------------- |---------:|----------:|----------:|-------:|----------:|
|      WithAttribute | 4.708 ns | 0.1296 ns | 0.1940 ns | 0.0077 |      24 B |
| WithStaticFunction | 1.114 ns | 0.0408 ns | 0.0381 ns |      - |         - |
```